### PR TITLE
Fix heading references

### DIFF
--- a/src/apiAdapter.tsx
+++ b/src/apiAdapter.tsx
@@ -175,15 +175,15 @@ export class ApiAdapter {
      * to find relevant links.
      */
     compareLinkName(link: LinkCache, basename: string) {
-        
+
         // format link name to be comparable with base names:
 
         const path = link.link;
         // grab only the filename from a multi-folder path
         const filenameOnly = path.split("/").slice(-1)[0]
 
-        // strip any block references from the end and the ".md" extension
-        const linkname = filenameOnly.split("#^")[0].split(".md")[0]
+        // strip any block and heading references from the end and the ".md" extension
+        const linkname = filenameOnly.split(/[\#\^]/)[0].split(".md")[0]
 
         if (linkname.toLowerCase() === basename.toLowerCase()) {
             return true

--- a/src/apiAdapter.tsx
+++ b/src/apiAdapter.tsx
@@ -185,10 +185,7 @@ export class ApiAdapter {
         // strip any block and heading references from the end and the ".md" extension
         const linkname = filenameOnly.split(/[\#\^]/)[0].split(".md")[0]
 
-        if (linkname.toLowerCase() === basename.toLowerCase()) {
-            return true
-        }
-        return false
+        return linkname.toLowerCase() === basename.toLowerCase()
     }
 
 


### PR DESCRIPTION
In the released version, if you have a link to a heading like `[[file#heading]]` it will appear with an empty summary in the influx pane. This is because `apiAdapter.compareLinkName` was only stripping block references but not heading references, so the correct summary could not be attached to the backlink. I have fixed this and tested that it behaves correctly on my local installation. Please let me know if you have any feedback or requests for further changes!