### PR TITLE
fix plugin not working after 1.7.6

### DIFF
--- a/src/InfluxFile.tsx
+++ b/src/InfluxFile.tsx
@@ -40,20 +40,53 @@ export default class InfluxFile {
     }
 
     async makeInfluxList() {
-        this.backlinks = this.api.getBacklinks(this.file) // Must refresh in case of renamings.
-        const inlinkingFilesNew: InlinkingFile[] = []
-        const backlinksAsFiles = Object.keys(this.backlinks.data)
-            .filter((pathAsKey) => pathAsKey !== this.file.path // Exclude mentions of self
-                && this.api.isIncludableSource(pathAsKey)) // Exclude by regex patterns
-            .map((pathAsKey) => this.api.getFileByPath(pathAsKey))
-        await Promise.all(backlinksAsFiles.map(async (file: TFile) => {
-            const inlinkingFile = new InlinkingFile(file, this.api)
-            await inlinkingFile.makeSummary(this)
-            inlinkingFilesNew.push(inlinkingFile)
-        }))
-        this.inlinkingFiles = inlinkingFilesNew
-    }
+        // 1. Get the Map from getBacklinks
+        this.backlinks = this.api.getBacklinks(this.file);
+        // console.log('Backlinks data:', this.backlinks.data);
+        
+        // 2. Create an array of valid paths
+        const validPaths: string[] = [];
+        // Convert Map-like structure to entries and iterate
+        const entries = this.backlinks.data instanceof Map ? 
+            Array.from(this.backlinks.data) : 
+            Object.entries(this.backlinks.data);
+            
+        for (const [pathAsKey, backlinkArray] of entries) {
+            // console.log('Processing path:', pathAsKey);
+            // console.log('Backlink array:', backlinkArray);
+            // console.log('Current file path:', this.file.path);
+            // console.log('Is includable source:', await this.api.isIncludableSource(pathAsKey));
+            
+            const isIncludable = await this.api.isIncludableSource(pathAsKey);
+            if (pathAsKey !== this.file.path && isIncludable) {
+                validPaths.push(pathAsKey);
+                // console.log('Added valid path:', pathAsKey);
+            } else {
+                console.log('Path rejected because:', {
+                    isSameAsCurrentFile: pathAsKey === this.file.path,
+                    isIncludableSource: isIncludable
+                });
+            }
+        }
+        // console.log('Valid paths collected:', validPaths);
 
+        // 3. Convert those paths to TFile objects
+        const backlinksAsFiles = validPaths.map((pathAsKey) => this.api.getFileByPath(pathAsKey));
+        // console.log('Converted to TFiles:', backlinksAsFiles);
+
+        // 4. Create InlinkingFile objects & do the summary calls
+        const inlinkingFilesNew: InlinkingFile[] = [];
+        await Promise.all(backlinksAsFiles.map(async (file) => {
+            // console.log('Processing file for InlinkingFile:', file?.path);
+            const inlinkingFile = new InlinkingFile(file, this.api);
+            await inlinkingFile.makeSummary(this);
+            inlinkingFilesNew.push(inlinkingFile);
+        }));
+        // console.log('Created InlinkingFiles:', inlinkingFilesNew);
+
+        // 5. Store them on this.inlinkingFiles
+        this.inlinkingFiles = inlinkingFilesNew;
+    }
     async renderAllMarkdownBlocks() {
 
         // Avoid rendering if no-show

--- a/src/apiAdapter.tsx
+++ b/src/apiAdapter.tsx
@@ -1,4 +1,4 @@
-import { App, TFile, CachedMetadata, LinkCache, MarkdownRenderer } from 'obsidian';
+import { App, TFile, CachedMetadata, LinkCache, MarkdownRenderer, Component } from 'obsidian';
 import { InlinkingFile } from './InlinkingFile';
 import { DEFAULT_SETTINGS, ObsidianInfluxSettings } from './main';
 
@@ -9,67 +9,51 @@ export type ExtendedInlinkingFile = {
     inner: HTMLDivElement;
 }
 
-export class ApiAdapter {
+export class ApiAdapter extends Component {
     app: App;
 
     constructor(app: App) {
+        super();
         this.app = app
     }
-
-
+    
     /** =================
      * OBSIDIAN resources 
      * ==================
      */
-
-
     getFileByPath(path: string): TFile {
         const file = this.app.vault.getAbstractFileByPath(path)
         if (file instanceof TFile) {
             return file
         }
     }
-
-
     async readFile(file: TFile): Promise<string> {
         return await this.app.vault.read(file)
     }
-
-
     getMetadata(file: TFile): CachedMetadata {
         return this.app.metadataCache.getFileCache(file);
     }
-
-
     getBacklinks(file: TFile): BacklinksObject {
         // getBacklinksForFile is not document officially, so it might break at some point.
         // @ts-ignore
         return this.app.metadataCache.getBacklinksForFile(file)
     }
-
-
     async renderMarkdown(markdown: string): Promise<HTMLDivElement> {
         const div = document.createElement('div');
-        await MarkdownRenderer.renderMarkdown(markdown, div, '/', null)
+        await MarkdownRenderer.renderMarkdown(markdown, div, '/', this)
         // @ts-ignore
         div.innerHTML = div.innerHTML.replaceAll('type="checkbox"', 'type="checkbox" disabled="true"')
         return div
     }
-
-
     getSettings(): ObsidianInfluxSettings {
         // @ts-ignore
         const settings = this.app.plugins?.plugins?.influx?.data?.settings || DEFAULT_SETTINGS
         return settings
     }
-
-
     /** =================
      * INFLUX utils 
      * ==================
      */
-
-
     /** For a given file, should Influx component be shown on it's page? */
     getShowStatus(file: TFile): boolean {
         const settings: Partial<ObsidianInfluxSettings> = this.getSettings()
@@ -80,8 +64,6 @@ export class ApiAdapter {
                 : false
         return show
     }
-
-
     isIncludableSource(path: string): boolean {
         const settings: Partial<ObsidianInfluxSettings> = this.getSettings()
         const patterns = settings.sourceBehaviour === 'OPT_IN' ? settings.sourceInclusionPattern : settings.sourceExclusionPattern
@@ -91,16 +73,12 @@ export class ApiAdapter {
                 : false
         return isIncludable
     }
-
-
     /** For a given file, should Influx component be shown as collapsed on it's page? */
     getCollapsedStatus(file: TFile): boolean {
         const settings: Partial<ObsidianInfluxSettings> = this.getSettings()
         const matched = this.patternMatchingFn(file.path, settings.collapsedPattern)
         return matched
     }
-
-
     patternMatchingFn = (path: string, _patterns: string[]): boolean => {
         const patterns = _patterns.filter((_path: string) => _path.length > 0)
         const pathMatchesRegex = (pattern: string): boolean => {
@@ -114,8 +92,6 @@ export class ApiAdapter {
         const matched = patterns.some(pathMatchesRegex);
         return matched
     };
-
-
     /** A sort function to order notes correctly, based on settings. */
     makeComparisonFn(): (a: InlinkingFile, b: InlinkingFile) => 0 | 1 | -1 {
         const settings: Partial<ObsidianInfluxSettings> = this.getSettings()
@@ -141,11 +117,7 @@ export class ApiAdapter {
             }
 
         }
-
-
     }
-
-
     async renderAllMarkdownBlocks(inlinkingsFiles: InlinkingFile[]): Promise<ExtendedInlinkingFile[]> {
         const settings: Partial<ObsidianInfluxSettings> = this.getSettings()
         const comparator = this.makeComparisonFn()
@@ -169,15 +141,11 @@ export class ApiAdapter {
             }))
         return components
     }
-
-
     /** comparison fn for filter in function to make contextual summaries,
      * to find relevant links.
      */
     compareLinkName(link: LinkCache, basename: string) {
-
         // format link name to be comparable with base names:
-
         const path = link.link;
         // grab only the filename from a multi-folder path
         const filenameOnly = path.split("/").slice(-1)[0]
@@ -187,7 +155,4 @@ export class ApiAdapter {
 
         return linkname.toLowerCase() === basename.toLowerCase()
     }
-
-
-
-}
+} // Add this closing brace


### PR DESCRIPTION
# Fix: Influx plugin not working after Obsidian 1.7.6 update

As a daily user of this plugin, I felt the need dive in and fix it. This is a small update to get the plugin working under Obsidian's latest release 1.8.7.

I used the below comment from #88 to come up with a solution and with this new implementation it seems to be working for me and passes all the tests.

## On Maintainability

After diving in and getting a bit more familiar with the code, I think I should be able to maintain this plugin if the creator is still looking for help.

## Comment that inspired the fix

> I think I got to the bottom of it with some heavy use of chatGPT. Seems a recent obsidian core update changed how backlink data is stored - now as a map and not an array. It needed to be in an array. To hotfix, 
> 
> 
> 
> 1. go to /.obsidian/plugins/influx/main.js, 
> 
> 2. search for the following function:
> 
> 
> 
> ```
> 
> makeInfluxList() {
> 
>     return __async(this, null, function* () {
> 
>       this.backlinks = this.api.getBacklinks(this.file);
> 
>       const inlinkingFilesNew = [];
> 
>       const backlinksAsFiles = Object.keys(this.backlinks.data).filter((pathAsKey) => pathAsKey !== this.file.path && this.api.isIncludableSource(pathAsKey)).map((pathAsKey) => this.api.getFileByPath(pathAsKey));
> 
>       yield Promise.all(backlinksAsFiles.map((file) => __async(this, null, function* () {
> 
>         const inlinkingFile = new InlinkingFile(file, this.api);
> 
>         yield inlinkingFile.makeSummary(this);
> 
>         inlinkingFilesNew.push(inlinkingFile);
> 
>       })));
> 
>       this.inlinkingFiles = inlinkingFilesNew;
> 
>     });
> 
> ```
> 
> 
> 
> 3.  replace it with this: 
> 
> 
> 
> ```
> 
> makeInfluxList() {
> 
> 
> 
>   return __async(this, null, function* () {
> 
>     // 1. Get the Map from getBacklinks
> 
>     this.backlinks = this.api.getBacklinks(this.file);
> 
>     
> 
>     // 2. Create an array of valid paths
> 
>     const validPaths = [];
> 
>     for (const [pathAsKey, backlinkArray] of this.backlinks.data) {
> 
>       // Exclude current note & check if includable
> 
>       if (pathAsKey !== this.file.path && this.api.isIncludableSource(pathAsKey)) {
> 
>         validPaths.push(pathAsKey);
> 
>       }
> 
>     }
> 
> 
> 
>     // 3. Convert those paths to TFile objects
> 
>     const backlinksAsFiles = validPaths.map((pathAsKey) => this.api.getFileByPath(pathAsKey));
> 
> 
> 
>     // 4. Create InlinkingFile objects & do the summary calls
> 
>     const inlinkingFilesNew = [];
> 
>     yield Promise.all(backlinksAsFiles.map((file) => __async(this, null, function* () {
> 
>       const inlinkingFile = new InlinkingFile(file, this.api);
> 
>       yield inlinkingFile.makeSummary(this);
> 
>       inlinkingFilesNew.push(inlinkingFile);
> 
>     })));
> 
> 
> 
>     // 5. Store them on this.inlinkingFiles
> 
>     this.inlinkingFiles = inlinkingFilesNew;
> 
>   });
> 
> }
> 
> ```
> 
> 
> 
> Obviously a bit hackish to edit the compiled main.js, but it works for now! Maybe the developer can merge the fix in one day, but if not, hopefully this helps someone else who loves the functionality of this great plugin.  

 _Originally posted by @bvsbuild in [#88](https://github.com/jensmtg/influx/issues/88#issuecomment-2591095816)_
