### PR TITLE
Fix: Update GitHub Workflows and Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "20" # You might need to adjust this value to your own version
-          cache: 'yarn' # This speeds up builds by caching dependencies
+          # cache: 'yarn' # This speeds up builds by caching dependencies
       - name: Build
         id: build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "20" # You might need to adjust this value to your own version
-          cache: 'yarn' # This speeds up builds by caching dependencies
+          # cache: 'yarn' # This speeds up builds by caching dependencies
       - name: Build
         id: build
         run: |


### PR DESCRIPTION
## What Changed?

- Updated the GitHub Workflows to use latest version of their actions (Ex. `v1` to `v6`)
- Updated workflows to use node 20 instead of 16
- Added (disabled) option to cache the node installation (needs further discussion on handling of package managers)
- Enabled automatic CI runs for the `build.yml` workflow on Pull Requests
	- Verified [passing workflow run](https://github.com/semanticdata/influx/actions/runs/20867402040/job/59961761251) on forked repository
